### PR TITLE
website

### DIFF
--- a/docs/content/en/how-to-guides/demo/_index.md
+++ b/docs/content/en/how-to-guides/demo/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Demo howtos"
+linkTitle: "Demo howtos"
+type: docs
+description: >-
+     How to do various things with the demo
+---
+
+The demo runs entirely in the browser and does not store any information on a remote server.
+
+## Sharing elements with the demo
+
+### The sharing
+
+The sharing elements works by encoding the wtg elements in gzipped' base64. Then it is added to the url with the `wtg=` parameter.
+
+example: [https://owulveryck.github.io/wardleyToGo/demo/?wtg=H4sIAAAAAAAAE8tIzcnJV9BVSEnNzQcAdsIHTgwAAAA%3D](https://owulveryck.github.io/wardleyToGo/demo/?wtg=H4sIAAAAAAAAE8tIzcnJV9BVSEnNzQcAdsIHTgwAAAA%3D)
+
+### The gist/GitHub integration
+
+It is possible to reference and render wtg files hosted on github or gist.github.com.
+
+To do so, get the url of the raw file, for example [https://raw.githubusercontent.com/owulveryck/wardleyToGo/main/docs/content/en/illustration.wtg](https://raw.githubusercontent.com/owulveryck/wardleyToGo/main/docs/content/en/illustration.wtg)
+
+Then append it to the demo url with the `url=` param:
+
+exemple:
+
+[https://owulveryck.github.io/wardleyToGo/demo/?url=https://raw.githubusercontent.com/owulveryck/wardleyToGo/main/docs/content/en/illustration.wtg(https://owulveryck.github.io/wardleyToGo/demo/?url=https://raw.githubusercontent.com/owulveryck/wardleyToGo/main/docs/content/en/illustration.wtg)
+

--- a/docs/content/en/reference/wtg/pipeline.md
+++ b/docs/content/en/reference/wtg/pipeline.md
@@ -1,0 +1,29 @@
+---
+title: "Pipeline"
+linkTitle: "Pipeline"
+type: docs
+weight: 10
+description: >-
+     This is a description of the pipeline
+---
+
+## Declaration
+
+Considering `P` the main pipeline element.
+Each component belonging to the `P` pipeline is attached via a semicolon `:`.
+
+example: `P:a` means `a` is a component of the `P` pipeline
+
+as `a` is a component, it can be configured like any other component. Its evolution is configured like any other component (with the `|.|.|.|.|` syntax)
+
+## Value chain
+
+A pipeline is declared on the value chain:
+
+ex: 
+
+- `P:a - P2`: `a` is linked to `P2``
+- `P = P2:b`: `P` is linked to `b`
+- `P:a - P2:b`: `a` is linked to `b`
+
+_Note_ when a pipeline is declared, the `type` of the host is set to `Pipeline`


### PR DESCRIPTION
- feat: skeleton of the website
- housekeeping: docs is now in the website
- ignoring the wasm binary
- demo is hugo compliant
- fix: content
- feat: references
- feat: landing page
- feat: colors
- fix: build the website after the wasm demo has been compiled
- fix: language reference
- feat: add demo
- feat: pipeline
